### PR TITLE
Implement I2C Display to display variables

### DIFF
--- a/python/chamber/backend/main.py
+++ b/python/chamber/backend/main.py
@@ -93,6 +93,7 @@ dht = adafruit_dht.DHT22(DHT_PIN, use_pulseio=False)
 try:
     display = sh1106(lumaI2C(address=0x3C))
 except:
+    logging.warning("Display SH1106 not recognized in I2C bus on address 0x3C.")
     display = None
 display_font = ImageFont.load_default()
 

--- a/python/chamber/backend/main.py
+++ b/python/chamber/backend/main.py
@@ -90,7 +90,10 @@ dxl = Ax12(DXL_ID)
 dxl.set_moving_speed(DXL_SPEED)
 dxl.set_goal_position(0)
 dht = adafruit_dht.DHT22(DHT_PIN, use_pulseio=False)
-display = sh1106(lumaI2C(address=0x3C))
+try:
+    display = sh1106(lumaI2C(address=0x3C))
+except:
+    display = None
 display_font = ImageFont.load_default()
 
 try:
@@ -212,6 +215,10 @@ def read_sensor_data():
 def update_display():
     """Update the frame in the OLED display"""
     while not stop_event.is_set():
+        if display is None:
+            time.sleep(DISPLAY_UPDATE_TIME)
+            continue
+
         field_mode = bh is None and tsl is None and ltr is None
         image = Image.new("1", (display.width, display.height))
         draw = ImageDraw.Draw(image)

--- a/python/chamber/backend/requirements.txt
+++ b/python/chamber/backend/requirements.txt
@@ -16,10 +16,11 @@ astroid==4.0.2
 binho-host-adapter==0.1.6
 black==25.11.0
 blinker==1.9.0
+cbor2==5.7.1
 click==8.2.0
 colorama==0.4.6
 dill==0.4.0
-#dynamixel_sdk==3.8.3
+# dynamixel_sdk==4.0.1
 fastapi==0.115.12
 Flask==3.1.1
 h11==0.16.0
@@ -27,6 +28,8 @@ idna==3.10
 isort==7.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
+luma.core==2.5.2
+luma.oled==3.14.0
 MarkupSafe==3.0.3
 mccabe==0.7.0
 mypy_extensions==1.1.0
@@ -34,6 +37,7 @@ numpy==2.2.5
 opencv-python==4.11.0.86
 packaging==25.0
 pathspec==0.12.1
+pillow==12.0.0
 platformdirs==4.5.0
 pydantic==2.11.4
 pydantic_core==2.33.2
@@ -46,6 +50,7 @@ pyusb==1.3.1
 RPi.GPIO==0.7.1
 rpi_ws281x==5.0.0
 setuptools==75.8.0
+smbus2==0.5.0
 sniffio==1.3.1
 starlette==0.46.2
 sysv_ipc==1.1.0

--- a/python/chamber/frontend/config/nginx.conf
+++ b/python/chamber/frontend/config/nginx.conf
@@ -15,7 +15,7 @@ http {
         server_name _;
 
         location /api/ {
-            proxy_pass http://192.168.192.166:5000/;
+            proxy_pass http://192.168.100.118:5000/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Switch

Added a digital switch temporarily on pin 12 and defined it as Input
- If the switch is OFF the motor goes through the indexed angles in order
- If it's ON it goes in reverse
Updated the progress calculator to accommodate both modes

## Pre-session

Defined a function that gets called in both ways a new session can start
- Someone pressed the START button and the process was previously not running
- A request for `running=0` was received while the process was running
In this function are some statements that need to run at the beginning of every session for preparation
- Resets the progress to 0
- Reads the direction switch and sets the initial angle if it's on backwards mode
- Updates in memory the number of the next session directory

## Display

Added all the setup for the display with the `luma` library
The display constantly updates on a new thread showing the variables for `direction`, `running`, `progress` and `field_mode`
`field_mode` is calculated if all the I2C sensors are missing